### PR TITLE
Add support for ArcGIS Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ I'm looking for maintainer(s) to take over the project. It is a super simple pro
 Searches the (windows) system for arcgis and makes arcpy available to python (regardless of pythonpath/system path/registry settings)
 If ArcGIS is not found, an `ImportError` is thrown.
 
-## Example usage:
+Use `pro=True` to target ArcGIS Pro instead of ArcGIS Desktop.
+
+## Example usage
+
+### ArcGIS Desktop
 ```python
 try:
     import archook #The module which locates arcgis
@@ -18,6 +22,21 @@ try:
     import arcpy
 except ImportError:
     # do whatever you do if arcpy isnt there.
+```
+### ArcGIS Pro
+```python
+try:
+    import archook #The module which locates arcgis
+    archook.get_arcpy(pro=True)
+    import arcpy
+except ImportError:
+    # do whatever you do if arcpy isnt there.
+```
+
+**Note:** You may need to create a `conda-meta` directory in your Python interpreter's directory (referred to by `sys.prefix`) if you get an error like the following:
+
+```
+ImportError("arcpy needs to run within an active ArcGIS Conda environment")
 ```
 
 ## Installation

--- a/archook/archook.py
+++ b/archook/archook.py
@@ -27,10 +27,7 @@ def locate_arcgis(pro=False):
   '''
   try:
     if pro:
-      pro_key = _winreg.OpenKey(
-        _winreg.HKEY_LOCAL_MACHINE,
-        'SOFTWARE\\ESRI\\ArcGISPro'
-      )
+      pro_key = get_pro_key()
       install_dir = _winreg.QueryValueEx(pro_key, "InstallDir")[0]
     else:
       key = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,
@@ -85,10 +82,7 @@ def locate_conda():
   Returns the path to the ArcGIS Pro-managed conda environment.
   '''
   try:
-    pro_key = _winreg.OpenKey(
-        _winreg.HKEY_LOCAL_MACHINE,
-        'SOFTWARE\\ESRI\\ArcGISPro'
-      )
+    pro_key = get_pro_key()
     conda_root = _winreg.QueryValueEx(pro_key, 'PythonCondaRoot')[0]
     conda_env = _winreg.QueryValueEx(pro_key, 'PythonCondaEnv')[0]
     conda_path = os.path.join(conda_root, 'envs', conda_env)
@@ -97,3 +91,13 @@ def locate_conda():
     return conda_path
   except WindowsError:
     raise ImportError('Could not locate the Conda directory on this machine')
+
+def get_pro_key():
+  '''
+  Returns ArcGIS Pro's registry key.
+  '''
+  pro_key = _winreg.OpenKey(
+    _winreg.HKEY_LOCAL_MACHINE,
+    'SOFTWARE\\ESRI\\ArcGISPro'
+  )
+  return pro_key

--- a/archook/archook.py
+++ b/archook/archook.py
@@ -7,13 +7,17 @@ try:
   import _winreg
 except ImportError:
    import winreg as _winreg
+import os
 import sys
-from os import path
-def locate_arcgis():
+
+def locate_arcgis(pro=False):
   '''
-  Find the path to the ArcGIS Desktop installation.
+  Find the path to the ArcGIS Desktop installation, or the ArcGIS Pro installation
+  if `pro` argument is True.
 
   Keys to check:
+
+  ArcGIS Pro: HKLM/SOFTWARE/ESRI/ArcGISPro 'InstallDir'
 
   HLKM/SOFTWARE/ESRI/ArcGIS 'RealVersion' - will give the version, then we can use
   that to go to
@@ -22,41 +26,56 @@ def locate_arcgis():
   We may need to check HKLM/SOFTWARE/Wow6432Node/ESRI instead
   '''
   try:
-    key = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,
-                          'SOFTWARE\\Wow6432Node\\ESRI\\ArcGIS', 0)
+    if pro:
+      pro_key = _winreg.OpenKey(
+        _winreg.HKEY_LOCAL_MACHINE,
+        'SOFTWARE\\ESRI\\ArcGISPro'
+      )
+      install_dir = _winreg.QueryValueEx(pro_key, "InstallDir")[0]
+    else:
+      key = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,
+                            'SOFTWARE\\Wow6432Node\\ESRI\\ArcGIS', 0)
 
-    version = _winreg.QueryValueEx(key, "RealVersion")[0][:4]
+      version = _winreg.QueryValueEx(key, "RealVersion")[0][:4]
 
-    key_string = "SOFTWARE\\Wow6432Node\\ESRI\\Desktop{0}".format(version)
-    desktop_key = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,
-                                  key_string, 0)
+      key_string = "SOFTWARE\\Wow6432Node\\ESRI\\Desktop{0}".format(version)
+      desktop_key = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,
+                                    key_string, 0)
 
-    install_dir = _winreg.QueryValueEx(desktop_key, "InstallDir")[0]
+      install_dir = _winreg.QueryValueEx(desktop_key, "InstallDir")[0]
     return install_dir
   except WindowsError:
     raise ImportError("Could not locate the ArcGIS directory on this machine")
 
-def get_arcpy():  
+def get_arcpy(pro=False):  
   '''
   Allows arcpy to imported on 'unmanaged' python installations (i.e. python installations
   arcgis is not aware of).
   Gets the location of arcpy and related libs and adds it to sys.path
+  Looks for ArcGIS Pro if `pro` argument is True.
   '''
-  install_dir = locate_arcgis()  
-  arcpy = path.join(install_dir, "arcpy")
-  # Check we have the arcpy directory.
-  if not path.exists(arcpy):
-    raise ImportError("Could not find arcpy directory in {0}".format(install_dir))
+  install_dir = locate_arcgis(pro)
+  if pro:
+    os.environ['PATH'] = ';'.join((os.path.join(install_dir, 'bin'), os.environ['PATH']))
+    sys.path.append(os.path.join(install_dir, 'bin'))
+    sys.path.append(os.path.join(install_dir, r'Resources\ArcPy'))
+    sys.path.append(os.path.join(install_dir, r'Resources\ArcToolbox\Scripts'))
+    sys.path.append(os.path.join(install_dir, r'bin\Python\envs\arcgispro-py3\Lib\site-packages'))
+  else:
+    arcpy = os.path.join(install_dir, "arcpy")
+    # Check we have the arcpy directory.
+    if not os.path.exists(arcpy):
+      raise ImportError("Could not find arcpy directory in {0}".format(install_dir))
 
-  # First check if we have a bin64 directory - this exists when arcgis is 64bit
-  bin_dir = path.join(install_dir, "bin64")
-  
-  # check if we are using a 64-bit version of Python
-  is_64bits = sys.maxsize > 2**32
-  
-  if not path.exists(bin_dir) or is_64bits == False:
-    # Fall back to regular 'bin' dir otherwise.
-    bin_dir = path.join(install_dir, "bin")
+    # First check if we have a bin64 directory - this exists when arcgis is 64bit
+    bin_dir = os.path.join(install_dir, "bin64")
+    
+    # check if we are using a 64-bit version of Python
+    is_64bits = sys.maxsize > 2**32
+    
+    if not os.path.exists(bin_dir) or is_64bits == False:
+      # Fall back to regular 'bin' dir otherwise.
+      bin_dir = os.path.join(install_dir, "bin")
 
-  scripts = path.join(install_dir, "ArcToolbox", "Scripts")  
-  sys.path.extend([arcpy, bin_dir, scripts])
+    scripts = os.path.join(install_dir, "ArcToolbox", "Scripts")  
+    sys.path.extend([arcpy, bin_dir, scripts])

--- a/archook/archook.py
+++ b/archook/archook.py
@@ -60,7 +60,7 @@ def get_arcpy(pro=False):
     sys.path.append(os.path.join(install_dir, 'bin'))
     sys.path.append(os.path.join(install_dir, r'Resources\ArcPy'))
     sys.path.append(os.path.join(install_dir, r'Resources\ArcToolbox\Scripts'))
-    sys.path.append(os.path.join(install_dir, r'bin\Python\envs\arcgispro-py3\Lib\site-packages'))
+    sys.path.append(os.path.join(locate_conda(), r'Lib\site-packages'))
   else:
     arcpy = os.path.join(install_dir, "arcpy")
     # Check we have the arcpy directory.
@@ -79,3 +79,21 @@ def get_arcpy(pro=False):
 
     scripts = os.path.join(install_dir, "ArcToolbox", "Scripts")  
     sys.path.extend([arcpy, bin_dir, scripts])
+
+def locate_conda():
+  '''
+  Returns the path to the ArcGIS Pro-managed conda environment.
+  '''
+  try:
+    pro_key = _winreg.OpenKey(
+        _winreg.HKEY_LOCAL_MACHINE,
+        'SOFTWARE\\ESRI\\ArcGISPro'
+      )
+    conda_root = _winreg.QueryValueEx(pro_key, 'PythonCondaRoot')[0]
+    conda_env = _winreg.QueryValueEx(pro_key, 'PythonCondaEnv')[0]
+    conda_path = os.path.join(conda_root, 'envs', conda_env)
+    if not os.path.exists(conda_path):
+      raise ImportError('Could not find Conda environment {} in root directory {}'.format(conda_env, conda_root))
+    return conda_path
+  except WindowsError:
+    raise ImportError('Could not locate the Conda directory on this machine')


### PR DESCRIPTION
  - Adds a `pro` argument to the `get_arcpy` and `locate_arcgis` functions that will look for an ArcGIS Pro installation if set to `True`
  - Default behavior for ArcGIS Desktop should be unchanged
  - Closes #14
