### PR TITLE
Update for Pro 3.3.x and Python 3.11

### DIFF
--- a/archook/archook.py
+++ b/archook/archook.py
@@ -109,17 +109,18 @@ def get_pro_paths():
     PRO_WIN_PATHS = inspect.cleandoc(
         r"""
         {C}
-        {C}\Library\mingw-w64
-        {C}\Library\usr\bin
         {C}\Library\bin
         {C}\Scripts
-        {P}\Python\Scripts
         {P}\bin
+        {P}\bin\Python
+        {P}\bin\Python\Library\bin
+        {P}\bin\Python\Scripts
+        {P}\bin\Python\condabin
         """.format(C=C, P=P))
     PRO_SYSPATHS = inspect.cleandoc(
         r"""
         {C}
-        {C}\python36.zip
+        {C}\python311.zip
         {C}\DLLs
         {C}\lib
         {C}\lib\site-packages
@@ -147,10 +148,9 @@ def get_arcpy(pro=False):
         # pro_conda_dir = locate_pro_conda()
 
         winpaths, syspaths = get_pro_paths()
-        # update Windows PATH
-        wp = os.environ["PATH"].split(";")  # save incoming path
-        [wp.insert(0, x) for x in winpaths]  # prepend our new syspath
-        os.environ["PATH"] = ";".join(wp)  # write back to environment
+        # Explicitly add directories to DLL search path. Refer to https://docs.python.org/3/library/os.html#os.add_dll_directory
+        for wp in winpaths:
+            os.add_dll_directory(wp)
         # update sys.path
         [sys.path.insert(0, x) for x in syspaths]
 

--- a/archook/archook.py
+++ b/archook/archook.py
@@ -110,12 +110,7 @@ def get_pro_paths():
         r"""
         {C}
         {C}\Library\bin
-        {C}\Scripts
         {P}\bin
-        {P}\bin\Python
-        {P}\bin\Python\Library\bin
-        {P}\bin\Python\Scripts
-        {P}\bin\Python\condabin
         """.format(C=C, P=P))
     PRO_SYSPATHS = inspect.cleandoc(
         r"""


### PR DESCRIPTION
As of Python 3.8, the PATH environment variable is [no longer used to resolve DLL dependencies](https://docs.python.org/3/whatsnew/3.8.html#bpo-36085-whatsnew). Instead [`add_dll_directory()`](https://docs.python.org/3/library/os.html#os.add_dll_directory) should be used. Note that this function will throw an error if the path does not exist, so I have also removed some paths that I found to no longer exist at Pro 3.3.x.

Ref: https://github.com/python/cpython/issues/80266